### PR TITLE
[Update] Craft-Helpers: Allow filter of entries

### DIFF
--- a/apollo/queries/navigations.gql
+++ b/apollo/queries/navigations.gql
@@ -5,17 +5,37 @@ query Navigations($section: String, $site: String) {
     title
     # uid is the same for each translated entry in a multisite/multilang setup
     uid
+    ...on pages_pages_Entry {
+      appearsInNavigation
+    }
+    ...on news_news_Entry {
+      appearsInNavigation
+    }
     children {
       slug
       uri
       uid
+      ...on pages_pages_Entry {
+        appearsInNavigation
+      }
+      ...on news_news_Entry {
+        appearsInNavigation
+      }
       title
       children {
         slug
         uri
         uid
+        ...on pages_pages_Entry {
+          appearsInNavigation
+        }
+        ...on news_news_Entry {
+          appearsInNavigation
+        }
         title
       }
     }
   }
 }
+
+

--- a/fetch.js
+++ b/fetch.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import { generateDataJSON } from '@wearelucid/vuecid-craft-helpers'
-// import generateDataJSON from './packages/vuecid-craft-helpers/dist/data/generateDataJSON.js'
+// import { generateDataJSON } from '@wearelucid/vuecid-craft-helpers'
+import generateDataJSON from './packages/vuecid-craft-helpers/dist/data/generateDataJSON.js'
 import config from './config.js'
 
 // gql files can't just be imported in node: https://github.com/ardatan/graphql-import-node
@@ -30,6 +30,7 @@ function fetchNavigations() {
     graphQLQuery,
     compressJSON: true, // setting this to false may help debugging :-)
     sections,
+    propertiesToFilter: ['appearsInNavigation'],
     bundleName: 'navigations',
     savePath: './static/data',
     langs

--- a/packages/vuecid-craft-helpers/dist/data/generateDataJSON.js
+++ b/packages/vuecid-craft-helpers/dist/data/generateDataJSON.js
@@ -33,6 +33,8 @@ function _generateDataJSON() {
         compressJSON,
         _ref$sections,
         sections,
+        _ref$propertiesToFilt,
+        propertiesToFilter,
         savePath,
         bundleName,
         _ref$langs,
@@ -47,29 +49,28 @@ function _generateDataJSON() {
         _iteratorNormalCompletion2,
         _didIteratorError2,
         _iteratorError2,
+        _loop,
         _iterator2,
         _step2,
-        section,
-        pages,
-        _args = arguments;
+        _args2 = arguments;
 
-    return _regenerator["default"].wrap(function _callee$(_context) {
+    return _regenerator["default"].wrap(function _callee$(_context2) {
       while (1) {
-        switch (_context.prev = _context.next) {
+        switch (_context2.prev = _context2.next) {
           case 0:
-            _ref = _args.length > 0 && _args[0] !== undefined ? _args[0] : {}, endpoint = _ref.endpoint, graphQLQuery = _ref.graphQLQuery, _ref$compressJSON = _ref.compressJSON, compressJSON = _ref$compressJSON === void 0 ? true : _ref$compressJSON, _ref$sections = _ref.sections, sections = _ref$sections === void 0 ? [] : _ref$sections, savePath = _ref.savePath, bundleName = _ref.bundleName, _ref$langs = _ref.langs, langs = _ref$langs === void 0 ? [] : _ref$langs;
+            _ref = _args2.length > 0 && _args2[0] !== undefined ? _args2[0] : {}, endpoint = _ref.endpoint, graphQLQuery = _ref.graphQLQuery, _ref$compressJSON = _ref.compressJSON, compressJSON = _ref$compressJSON === void 0 ? true : _ref$compressJSON, _ref$sections = _ref.sections, sections = _ref$sections === void 0 ? [] : _ref$sections, _ref$propertiesToFilt = _ref.propertiesToFilter, propertiesToFilter = _ref$propertiesToFilt === void 0 ? [] : _ref$propertiesToFilt, savePath = _ref.savePath, bundleName = _ref.bundleName, _ref$langs = _ref.langs, langs = _ref$langs === void 0 ? [] : _ref$langs;
             entries = {};
-            _context.prev = 2;
+            _context2.prev = 2;
             // Actually for each language is equal to each craft site in a multisite setup!
             _iteratorNormalCompletion = true;
             _didIteratorError = false;
             _iteratorError = undefined;
-            _context.prev = 6;
+            _context2.prev = 6;
             _iterator = langs[Symbol.iterator]();
 
           case 8:
             if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
-              _context.next = 42;
+              _context2.next = 39;
               break;
             }
 
@@ -79,114 +80,146 @@ function _generateDataJSON() {
             _iteratorNormalCompletion2 = true;
             _didIteratorError2 = false;
             _iteratorError2 = undefined;
-            _context.prev = 14;
+            _context2.prev = 14;
+            _loop =
+            /*#__PURE__*/
+            _regenerator["default"].mark(function _loop() {
+              var section, pages;
+              return _regenerator["default"].wrap(function _loop$(_context) {
+                while (1) {
+                  switch (_context.prev = _context.next) {
+                    case 0:
+                      section = _step2.value;
+                      _context.next = 3;
+                      return _axios["default"].post(endpoint, {
+                        // have to retransform AST gql template literal back to query string:
+                        // https://stackoverflow.com/a/57873339/1121268
+                        query: (0, _printer.print)(graphQLQuery),
+                        variables: {
+                          section: section,
+                          site: language.handle || 'default'
+                        }
+                      }).then(function (_ref2) {
+                        var data = _ref2.data;
+                        return data.data.entries;
+                      });
+
+                    case 3:
+                      pages = _context.sent;
+
+                      // filter out entries, that should not appear in JSON
+                      // Assuming that the property is a checkbox, where craft returns an empty array if false.
+                      // e.g.: "appearsInNavigation": [] || "appearsInNavigation": ["true"],
+                      if (propertiesToFilter && propertiesToFilter.length) {
+                        propertiesToFilter.forEach(function (property) {
+                          pages = pages.filter(function (page) {
+                            // if the entry does not even have the key we return
+                            if (!page[property]) return true; // check if first array item is true, then leave entry in array
+
+                            return page[property][0] ? page[property][0] : false;
+                          });
+                        });
+                      } // save sections in language object
+
+
+                      entries[language.lang][section] = pages;
+
+                    case 6:
+                    case "end":
+                      return _context.stop();
+                  }
+                }
+              }, _loop);
+            });
             _iterator2 = sections[Symbol.iterator]();
 
-          case 16:
+          case 17:
             if (_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done) {
-              _context.next = 25;
+              _context2.next = 22;
               break;
             }
 
-            section = _step2.value;
-            _context.next = 20;
-            return _axios["default"].post(endpoint, {
-              // have to retransform AST gql template literal back to query string:
-              // https://stackoverflow.com/a/57873339/1121268
-              query: (0, _printer.print)(graphQLQuery),
-              variables: {
-                section: section,
-                site: language.handle || 'default'
-              }
-            }).then(function (_ref2) {
-              var data = _ref2.data;
-              return data.data.entries;
-            });
+            return _context2.delegateYield(_loop(), "t0", 19);
 
-          case 20:
-            pages = _context.sent;
-            // save sections in language object
-            entries[language.lang][section] = pages;
+          case 19:
+            _iteratorNormalCompletion2 = true;
+            _context2.next = 17;
+            break;
 
           case 22:
-            _iteratorNormalCompletion2 = true;
-            _context.next = 16;
+            _context2.next = 28;
             break;
 
-          case 25:
-            _context.next = 31;
-            break;
-
-          case 27:
-            _context.prev = 27;
-            _context.t0 = _context["catch"](14);
+          case 24:
+            _context2.prev = 24;
+            _context2.t1 = _context2["catch"](14);
             _didIteratorError2 = true;
-            _iteratorError2 = _context.t0;
+            _iteratorError2 = _context2.t1;
 
-          case 31:
-            _context.prev = 31;
-            _context.prev = 32;
+          case 28:
+            _context2.prev = 28;
+            _context2.prev = 29;
 
             if (!_iteratorNormalCompletion2 && _iterator2["return"] != null) {
               _iterator2["return"]();
             }
 
-          case 34:
-            _context.prev = 34;
+          case 31:
+            _context2.prev = 31;
 
             if (!_didIteratorError2) {
-              _context.next = 37;
+              _context2.next = 34;
               break;
             }
 
             throw _iteratorError2;
 
-          case 37:
-            return _context.finish(34);
+          case 34:
+            return _context2.finish(31);
 
-          case 38:
-            return _context.finish(31);
+          case 35:
+            return _context2.finish(28);
+
+          case 36:
+            _iteratorNormalCompletion = true;
+            _context2.next = 8;
+            break;
 
           case 39:
-            _iteratorNormalCompletion = true;
-            _context.next = 8;
+            _context2.next = 45;
             break;
 
-          case 42:
-            _context.next = 48;
-            break;
-
-          case 44:
-            _context.prev = 44;
-            _context.t1 = _context["catch"](6);
+          case 41:
+            _context2.prev = 41;
+            _context2.t2 = _context2["catch"](6);
             _didIteratorError = true;
-            _iteratorError = _context.t1;
+            _iteratorError = _context2.t2;
 
-          case 48:
-            _context.prev = 48;
-            _context.prev = 49;
+          case 45:
+            _context2.prev = 45;
+            _context2.prev = 46;
 
             if (!_iteratorNormalCompletion && _iterator["return"] != null) {
               _iterator["return"]();
             }
 
-          case 51:
-            _context.prev = 51;
+          case 48:
+            _context2.prev = 48;
 
             if (!_didIteratorError) {
-              _context.next = 54;
+              _context2.next = 51;
               break;
             }
 
             throw _iteratorError;
 
-          case 54:
-            return _context.finish(51);
+          case 51:
+            return _context2.finish(48);
 
-          case 55:
-            return _context.finish(48);
+          case 52:
+            return _context2.finish(45);
 
-          case 56:
+          case 53:
             console.log("\uD83D\uDCE1 Fetched entries: ", entries); // save entries for each site in one file
 
             (0, _saveFile["default"])({
@@ -194,34 +227,21 @@ function _generateDataJSON() {
               bundleName: bundleName,
               savePath: savePath,
               compressJSON: compressJSON
-            }); // // filter out sections which match ignoreProperties
-            // if (payload.ignore) {
-            //   payload.ignore.forEach(propertyToIgnore => {
-            //     entries[section] = pages.filter(page => {
-            //       // if the entry does not even have the key we return
-            //       if (!(propertyToIgnore.key in page)) return true
-            //       // leave in array if the key is != the value
-            //       return page[propertyToIgnore.key] !== propertyToIgnore.value
-            //     })
-            //   })
-            // } else {
-            //   entries[section] = pages
-            // }
-
-            _context.next = 63;
+            });
+            _context2.next = 60;
             break;
 
-          case 60:
-            _context.prev = 60;
-            _context.t2 = _context["catch"](2);
-            console.log('generateDataJSON: 💾❌ loadentries() action failed 😢: ', _context.t2);
+          case 57:
+            _context2.prev = 57;
+            _context2.t3 = _context2["catch"](2);
+            console.log('generateDataJSON: 💾❌ loadentries() action failed 😢: ', _context2.t3);
 
-          case 63:
+          case 60:
           case "end":
-            return _context.stop();
+            return _context2.stop();
         }
       }
-    }, _callee, null, [[2, 60], [6, 44, 48, 56], [14, 27, 31, 39], [32,, 34, 38], [49,, 51, 55]]);
+    }, _callee, null, [[2, 57], [6, 41, 45, 53], [14, 24, 28, 36], [29,, 31, 35], [46,, 48, 52]]);
   }));
   return _generateDataJSON.apply(this, arguments);
 }


### PR DESCRIPTION
allow filtering of entries:
In this example:

Backend entries have a checkbox (!) (it has to be a checkbox, because checkboxes return an empty array if false, and this is used within the helper), if the checkbox is missing the page wont appear in the navigation.

We could theoretically pass more than one of these filters.

Also make sure to iclude the property in the graphql request...